### PR TITLE
Update module accesses for Re and Pervasives

### DIFF
--- a/src/mParser_RE.ml
+++ b/src/mParser_RE.ml
@@ -28,7 +28,7 @@ module Regexp: MParser_Sig.Regexp = struct
     [ `Anchored ]
 
   let make pattern =
-    Re_perl.(compile (re ~opts:compile_flags pattern))
+    Re.Perl.(compile (re ~opts:compile_flags pattern))
 
   let get_substring s idx =
     try

--- a/src/mParser_Utils.ml
+++ b/src/mParser_Utils.ml
@@ -26,7 +26,7 @@ module IO = struct
     let rec iter chars_read =
       let pos' = pos + chars_read in
       let length' = length - chars_read in
-      let chars = Pervasives.input chn buffer pos' length' in
+      let chars = Stdlib.input chn buffer pos' length' in
       if chars > 0 then
         iter (chars_read + chars)
       else


### PR DESCRIPTION
Hi @murmour  👋 . I'm using mparser in [comby](https://github.com/comby-tools/comby) and looking to help get an updated version of `mparser` into opam :-) 

This is one change we'd need, since `Re_perl` and `Pervasives` are deprecated in favor of `Re.Perl` and `Stdlib`. Can I help with anything to get this into `opam`, looks like that's the plan based on https://github.com/murmour/mparser/pull/10 :-)