### PR TITLE
Provide angstrom style infix functions for *> and <*.

### DIFF
--- a/src/mParser.ml
+++ b/src/mParser.ml
@@ -1,4 +1,3 @@
-
 (* MParser, a simple monadic parser combinator library
    -----------------------------------------------------------------------------
    Copyright (C) 2008, Holger Arnold
@@ -407,8 +406,12 @@ let (>>=) = bind
 let (>>) p q =
   p >>= fun _ -> q
 
+let ( *> ) = (>>)
+
 let (<<) p q =
   p >>= fun x -> q >> return x
+
+let ( <* ) = ( << )
 
 let (>>>) = (>>)
 

--- a/src/mParser.mli
+++ b/src/mParser.mli
@@ -1,4 +1,3 @@
-
 (* MParser, a simple monadic parser combinator library
    -----------------------------------------------------------------------------
    Copyright (C) 2008, Holger Arnold
@@ -335,10 +334,20 @@ val (>>=): ('a, 's) t -> ('a -> ('b, 's) t) -> ('b, 's) t
 (** [p >>= f] is equivalent to [bind p f] *)
 
 val (>>): ('a, 's) t -> ('b, 's) t -> ('b, 's) t
-(** [p >> q] is equivalent to [p >>= (fun _ -> q)]. *)
+(** [p >> q] runs [p], discards its result and then runs [q], and returns its
+    result. *)
+
+val ( *> ): ('a, 's) t -> ('b, 's) t -> ('b, 's) t
+(** [p *> q] runs [p], discards its result and then runs [q], and returns its
+    result. *)
 
 val (<<): ('a, 's) t -> ('b, 's) t -> ('a, 's) t
-(** [p << q] is equivalent to [p >>= (fun x -> q >> return x)]. *)
+(** [p << q] runs [p], then runs [q], discards its result, and returns the
+    result of [p]. *)
+
+val ( <* ): ('a, 's) t -> ('b, 's) t -> ('a, 's) t
+(** [p <* q] runs [p], then runs [q], discards its result, and returns the
+    result of [p]. *)
 
 val (>>>): ('a, 's) t -> ('b, 's) t -> ('b, 's) t
 (** Camlp4-compatible alternative to [>>]. *)


### PR DESCRIPTION
Minor addition of infix operators inline with [angstrom](https://github.com/inhabitedtype/angstrom/blob/master/lib/angstrom.mli#L406-L412).
I also reused the wording from angstrom for how these 4 functions work, I feel it is much clearer.
